### PR TITLE
Stack-safety follow-up

### DIFF
--- a/src/main/scala/caio/Caio.scala
+++ b/src/main/scala/caio/Caio.scala
@@ -234,8 +234,17 @@ object Caio {
             FoldCaioIO(io.redeem(FoldCaioError(c, l, _), FoldCaioSuccess(c, l, _)))
 
           case (KleisliCaio(f), ff :: fs) =>
-            f(c).flatMap { case (c, l, a) =>
-              safeFold(ff(a), c,  l, fs)
+            f(c) match {
+              case FoldCaioSuccess(c, l, a) =>
+                foldCaio(ff(a), c, l , fs)
+              case failure: FoldCaioFailure[_, _, _, _] =>
+                failure
+              case error: FoldCaioError[_, _, _, _] =>
+                error
+              case fold: FoldCaioIO[_, _, _, _] =>
+                fold.flatMap { case (c, l, a) =>
+                  safeFold(ff(a), c,  l, fs)
+                }
             }
 
           case (KleisliCaio(f), Nil) =>

--- a/src/main/scala/caio/Caio.scala
+++ b/src/main/scala/caio/Caio.scala
@@ -82,7 +82,7 @@ final private[caio] case class GetContextCaio[C, V, L]() extends Caio[C, V, L, C
 final private[caio] case class SetContextCaio[C, V, L](c:C) extends Caio[C, V, L, Unit]
 
 
-case class CaioUnhandledFailuresException[V](failure:NonEmptyList[V])
+case class CaioUnhandledFailuresException[V](failure: NonEmptyList[V])
   extends Exception("Caio failures have not been handled.")
 
 
@@ -202,9 +202,39 @@ final private[caio] case class FoldCaioIO[C, V, L, +A](io:IO[FoldCaioPure[C, V, 
 object Caio {
 
   private[caio] def foldIO[C, V, L, A](caio: Caio[C, V, L, A], c: C)(implicit M:Monoid[L]): IO[FoldCaioPure[C, V, L, A]] = {
+    type Continuation = (C, L, Any) => Caio[C, V, L, Any]
+    type ErrorRecovery = (C, L, Throwable) => Caio[C, V, L, Any]
+    type FailureRecovery = (C, L, NonEmptyList[V]) => Caio[C, V, L, Any]
+
+    sealed trait Handler
+    case class OnSuccess(f: Continuation) extends Handler
+    case class OnFailure(f: FailureRecovery) extends Handler
+    case class OnError(f: ErrorRecovery) extends Handler
+
     def tryOrError(value: => Caio[C, V, L, Any]): Caio[C, V, L, Any] =
       try value
       catch { case NonFatal(ex) => ErrorCaio(ex) }
+
+    @tailrec def nextHandler(fs: List[Handler]): Option[(Continuation, List[Handler])] =
+      fs match {
+        case OnSuccess(c) :: cs => Some((c, cs))
+        case _ :: cs => nextHandler(cs)
+        case Nil => None
+      }
+
+    @tailrec def nextErrorHandler(fs: List[Handler]): Option[(ErrorRecovery, List[Handler])] =
+      fs match {
+        case OnError(c) :: cs => Some((c, cs))
+        case _ :: cs => nextErrorHandler(cs)
+        case Nil => None
+      }
+
+    @tailrec def nextFailureHandler(fs: List[Handler]): Option[(FailureRecovery, List[Handler])] =
+      fs match {
+        case OnFailure(c) :: cs => Some((c, cs))
+        case _ :: cs => nextFailureHandler(cs)
+        case Nil => None
+      }
 
     /**
      * Recursive fold of Caio GADT.
@@ -216,150 +246,116 @@ object Caio {
      * @tparam B
      * @return
      */
-    def safeFold(caio: Caio[C, V, L, Any], c: C, l: L, fs: List[(C, L, Any) => Caio[C, V, L, Any]]): FoldCaio[C, V, L, Any] = {
-      @tailrec def foldCaio(caio: Caio[C, V, L, Any], c: C, l: L, fs: List[(C, L, Any) => Caio[C, V, L, Any]]): FoldCaio[C, V, L, Any] =
-        (caio, fs) match {
-          case (PureCaio(a), f :: fs) =>
-            foldCaio(tryOrError(f(c, l, a)), c,  l, fs)
-
-          case (PureCaio(a), Nil) =>
-            FoldCaioSuccess(c, l, a)
-
-          case (IOCaio(io), f :: fs) =>
-            FoldCaioIO(io.redeemWith(
-              e => IO.pure(FoldCaioError(c, l, e)),
-              a => safeFold(tryOrError(f(c, l, a)), c, l, fs).toIO
-            ))
-
-          case (IOCaio(io), Nil) =>
-            FoldCaioIO(io.redeem(FoldCaioError(c, l, _), FoldCaioSuccess(c, l, _)))
-
-          case (KleisliCaio(f), ff :: fs) =>
-            f(c) match {
-              case FoldCaioSuccess(c, l, a) =>
-                foldCaio(ff(c, l, a), c, l, fs)
-              case failure: FoldCaioFailure[_, _, _, _] =>
-                failure
-              case error: FoldCaioError[_, _, _, _] =>
-                error
-              case fold: FoldCaioIO[_, _, _, _] =>
-                fold.flatMap { case (c, l, a) =>
-                  safeFold(ff(c, l, a), c,  l, fs)
-                }
+    def safeFold(caio: Caio[C, V, L, Any], c: C, l: L, handlers: List[Handler]): FoldCaio[C, V, L, Any] = {
+      @tailrec def foldCaio(caio: Caio[C, V, L, Any], c: C, l: L, handlers: List[Handler]): FoldCaio[C, V, L, Any] =
+        caio match {
+          case PureCaio(a) =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(tryOrError(f(c, l, a)), c,  l, fs)
+              case None =>
+                FoldCaioSuccess(c, l, a)
             }
 
-          case (KleisliCaio(f), Nil) =>
-            try f(c)
-            catch { case NonFatal(ex) => FoldCaioError(c, l, ex) }
-
-          case (MapCaio(source, f), list) =>
-            foldCaio(source, c,  l, ((_: C, _: L, a: Any) => PureCaio[C, V, L, Any](f(a))) :: list)
-
-          case (BindCaio(source, f), list) =>
-            foldCaio(source, c, l, ((_: C, _: L, a: Any) => f(a)) :: list)
-
-          case (ErrorCaio(e), _) =>
-            FoldCaioError(c, l, e)
-
-          case (HandleErrorCaio(source, f), list) =>
-            safeFold(source, c, l, Nil) match {
-              case FoldCaioError(c2, l2, e) =>
-                foldCaio(tryOrError(f(e)), c2, l2, list)
-              case p: FoldCaioPure[C, V, L, _] if list.isEmpty =>
-                p
-              case p: FoldCaioPure[C, V, L, _] =>
-                p.flatMap { case (c, l, a) =>
-                  val f :: fs = list 
-                  safeFold(f(c, l, a), c,  l, fs)
-                }
-              case FoldCaioIO(io) =>
-                FoldCaioIO {
-                  io.flatMap {
-                    case FoldCaioError(c2, l2, e) =>
-                      safeFold(tryOrError(f(e)), c2, l2, list) match {
-                        case FoldCaioIO(io2) =>
-                          io2
-                        case p: FoldCaioPure[C, V, L, _] =>
-                          IO.pure(p)
-                      }
-                    case p: FoldCaioPure[C, V, L, _] if list.isEmpty =>
-                      IO.pure(p)
-                    case p: FoldCaioPure[C, V, L, _] =>
-                      p.flatMap { case (c, l, a) =>
-                        val f :: fs = list 
-                        safeFold(f(c, l, a), c,  l, fs)
-                      }.toIO
-                  }
-                }
+          case IOCaio(io) =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                FoldCaioIO(io.redeemWith(
+                  e => IO.pure(FoldCaioError(c, l, e)),
+                  a => safeFold(tryOrError(f(c, l, a)), c, l, fs).toIO
+                ))
+              case None =>
+                FoldCaioIO(io.redeem(FoldCaioError(c, l, _), FoldCaioSuccess(c, l, _)))
             }
 
-          case (FailureCaio(head, tail), _) =>
-            FoldCaioFailure(c, l, head, tail)
-
-          case (HandleFailureCaio(source, f), list) =>
-            safeFold(source, c, l, Nil) match {
-              case FoldCaioFailure(c2, l2, head, tail) =>
-                foldCaio(tryOrError(f(NonEmptyList(head, tail))), c2, l2, list)
-              case p: FoldCaioPure[C, V, L, _] if list.isEmpty =>
-                p
-              case p: FoldCaioPure[C, V, L, _] =>
-                p.flatMap { case (c, l, a) =>
-                  val f :: fs = list 
-                  safeFold(f(c, l, a), c,  l, fs)
+          case KleisliCaio(f) =>
+            nextHandler(handlers) match {
+              case Some((ff, fs)) =>
+                f(c) match {
+                  case FoldCaioSuccess(c, l, a) =>
+                    foldCaio(ff(c, l, a), c, l, fs)
+                  case failure: FoldCaioFailure[_, _, _, _] =>
+                    failure
+                  case error: FoldCaioError[_, _, _, _] =>
+                    error
+                  case fold: FoldCaioIO[_, _, _, _] =>
+                    fold.flatMap { case (c, l, a) =>
+                      safeFold(ff(c, l, a), c,  l, fs)
+                    }
                 }
-              case FoldCaioIO(io) =>
-                FoldCaioIO {
-                  io.flatMap {
-                    case FoldCaioFailure(c2, l2, head, tail) =>
-                      safeFold(tryOrError(f(NonEmptyList(head, tail))), c2, l2, list) match {
-                        case FoldCaioIO(io2) =>
-                          io2
-                        case p: FoldCaioPure[C, V, L, _] =>
-                          IO.pure(p)
-                      }
-                    case p: FoldCaioPure[C, V, L, _] if list.isEmpty =>
-                      IO.pure(p)
-                    case p: FoldCaioPure[C, V, L, _] =>
-                      p.flatMap { case (c, l, a) =>
-                        val f :: fs = list 
-                        safeFold(f(c, l, a), c,  l, fs)
-                      }.toIO
-                  }
-                }
+              case None =>
+                try f(c)
+                catch { case NonFatal(ex) => FoldCaioError(c, l, ex) }
             }
 
-          case (SetCaio(l2), f :: fs) =>
-            foldCaio(f(c, l2, ()), c, l2, fs)
+          case MapCaio(source, f) =>
+            foldCaio(source, c,  l, OnSuccess((_, _, a) => PureCaio(f(a))) :: handlers)
 
-          case (SetCaio(l2), Nil) =>
-            FoldCaioSuccess(c, l2, ())
+          case BindCaio(source, f) =>
+            foldCaio(source, c, l, OnSuccess((_, _, a) => f(a)) :: handlers)
 
-          case (TellCaio(l2), f :: fs) =>
-            foldCaio(f(c, l2, ()), c, M.combine(l, l2), fs)
+          case ErrorCaio(e) =>
+            nextErrorHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(tryOrError(f(c, l, e)), c,  l, fs)
+              case None =>
+                FoldCaioError(c, l, e)
+            }
 
-          case (TellCaio(l2), Nil) =>
-            FoldCaioSuccess(c, M.combine(l, l2), ())
+          case HandleErrorCaio(source, f) =>
+            foldCaio(source, c, l, OnError((_, _, e) => f(e)) :: handlers)
 
-          case (ListenCaio(source), list) =>
-            foldCaio(source, c,  l, ((_: C, l: L, a: Any) => PureCaio[C, V, L, Any](a ->  l)) :: list)
+          case FailureCaio(head, tail) =>
+            nextFailureHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(tryOrError(f(c, l, NonEmptyList(head, tail))), c, l, fs)
+              case None =>
+                FoldCaioFailure(c, l, head, tail)
+            }
 
-          case (CensorCaio(source, f), list) =>
-            foldCaio(source, c, l, ((_: C, l: L, a: Any) => SetCaio[C, V, L](f(l))) :: list)
+          case HandleFailureCaio(source, f) =>
+            foldCaio(source, c, l, OnFailure((_, _, e) => f(e)) :: handlers)
 
-          case (GetContextCaio(), f :: fs) =>
-            foldCaio(f(c, l, c), c, l, fs)
+          case SetCaio(l2) =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(f(c, l2, ()), c, l2, fs)
+              case None =>
+                FoldCaioSuccess(c, l2, ())
+            }
 
-          case (GetContextCaio(), Nil) =>
-            FoldCaioSuccess(c, l, c)
+          case TellCaio(l2) =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(f(c, l2, ()), c, M.combine(l, l2), fs)
+              case None =>
+                FoldCaioSuccess(c, M.combine(l, l2), ())
+            }
 
-          case (SetContextCaio(replaceC), f :: fs) =>
-            foldCaio(f(c, l, ()), replaceC, l, fs)
+          case ListenCaio(source) =>
+            foldCaio(source, c,  l, OnSuccess((_, l, a) => PureCaio(a ->  l)) :: handlers)
 
-          case (SetContextCaio(replaceC), Nil) =>
-            FoldCaioSuccess[C, V, L, Unit](replaceC, l, ())
+          case CensorCaio(source, f) =>
+            foldCaio(source, c, l, OnSuccess((_, l, a) => SetCaio(f(l))) :: handlers)
+
+          case GetContextCaio() =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(f(c, l, c), c, l, fs)
+              case None =>
+                FoldCaioSuccess(c, l, c)
+            }
+
+          case SetContextCaio(replaceC) =>
+            nextHandler(handlers) match {
+              case Some((f, fs)) =>
+                foldCaio(f(c, l, ()), replaceC, l, fs)
+              case None =>
+                FoldCaioSuccess[C, V, L, Unit](replaceC, l, ())
+            }
         }
 
-      foldCaio(caio, c, l, fs)
+      foldCaio(caio, c, l, handlers)
     }
 
     safeFold(caio, c, Monoid.empty[L], Nil).map(_.asInstanceOf[A]).toIO


### PR DESCRIPTION
A follow-up of #4

- [x] Change list of continuations from `List[Any => Caio[C, V, L, Any]]` to `List[(C, L, Any) =>Caio[C, V, L, Any]` and fix `ListenCaio` to use correct `l`
- [x] Make `HandleErrorCaio` stack-safe. 
- [x] Make `HandleFailureCaio` stack-safe.
- [x] Make `CensorCaio` stack-safe.
- [x] Make `KleisliCaio` stack-safe.

Notes:
- ApplicativeFail test is now passing
- All pre-existing tests are also passing
- All data constructors are now being handled properly (hope I'm not missing any case). Therefore, `safeFold` can keep that name

**To try later**:

Reimplement handler functions in terms of `dropWhile(_ != desiredHandler)` and maybe just keep `nextHandler` and use the body of the other two directly as they're being use in one place