### PR TITLE
Add variance to Caio

### DIFF
--- a/src/main/scala/caio/std/CaioApplicativeError.scala
+++ b/src/main/scala/caio/std/CaioApplicativeError.scala
@@ -5,7 +5,7 @@ import cats.ApplicativeError
 
 class CaioApplicativeError[C, V, L] extends CaioApplicative[C, V, L] with ApplicativeError[Caio[C, V, L, *], Throwable] {
   def raiseError[A](e: Throwable): Caio[C, V, L, A] =
-    ErrorCaio[V, L](e)
+    ErrorCaio[V](e)
 
   def handleErrorWith[A](fa: Caio[C, V, L, A])(f: Throwable => Caio[C, V, L, A]): Caio[C, V, L, A] =
     HandleErrorCaio(fa, f)

--- a/src/main/scala/caio/std/CaioApplicativeError.scala
+++ b/src/main/scala/caio/std/CaioApplicativeError.scala
@@ -5,7 +5,7 @@ import cats.ApplicativeError
 
 class CaioApplicativeError[C, V, L] extends CaioApplicative[C, V, L] with ApplicativeError[Caio[C, V, L, *], Throwable] {
   def raiseError[A](e: Throwable): Caio[C, V, L, A] =
-    ErrorCaio[V](e)
+    ErrorCaio(e)
 
   def handleErrorWith[A](fa: Caio[C, V, L, A])(f: Throwable => Caio[C, V, L, A]): Caio[C, V, L, A] =
     HandleErrorCaio(fa, f)

--- a/src/main/scala/caio/std/CaioApplicativeError.scala
+++ b/src/main/scala/caio/std/CaioApplicativeError.scala
@@ -5,7 +5,7 @@ import cats.ApplicativeError
 
 class CaioApplicativeError[C, V, L] extends CaioApplicative[C, V, L] with ApplicativeError[Caio[C, V, L, *], Throwable] {
   def raiseError[A](e: Throwable): Caio[C, V, L, A] =
-    ErrorCaio[C, V, L](e)
+    ErrorCaio[V, L](e)
 
   def handleErrorWith[A](fa: Caio[C, V, L, A])(f: Throwable => Caio[C, V, L, A]): Caio[C, V, L, A] =
     HandleErrorCaio(fa, f)

--- a/src/main/scala/caio/std/CaioSync.scala
+++ b/src/main/scala/caio/std/CaioSync.scala
@@ -6,7 +6,7 @@ import cats.effect.{IO, Sync}
 
 class CaioSync[C, V, L:Monoid] extends CaioBracket[C, V, L] with Sync[Caio[C, V, L, *]] {
   def suspend[A](thunk: => Caio[C, V, L, A]): Caio[C, V, L, A] =
-    KleisliCaio{ c =>
+    KleisliCaio[C, V, L, A] { c =>
       FoldCaioIO(IO.suspend(Caio.foldIO(thunk, c)))
     }
 

--- a/src/test/scala/caio/CaioTests.scala
+++ b/src/test/scala/caio/CaioTests.scala
@@ -186,6 +186,17 @@ class CaioTests extends AsyncFunSpec with Matchers {
 
       program.run(context).unsafeRunSync() shouldBe 6
     }
+
+    it("Should provide context") {
+      val program: CaioC[Any, Int] = {
+        ApplicativeAsk[CaioC[(Int, Int, Int), *], (Int, Int, Int)]
+          .ask
+          .map { case (a, b, c ) => a + b + c }
+          .provideContext((1, 2, 3))
+      }
+
+      program.run(()).unsafeRunSync() shouldBe 6
+    }
   }
 
   describe("Failures") {

--- a/src/test/scala/caio/CaioTests.scala
+++ b/src/test/scala/caio/CaioTests.scala
@@ -156,6 +156,7 @@ class CaioTests extends AsyncFunSpec with Matchers {
       program.run(()).unsafeRunSync() shouldBe 6
       program.run(false).unsafeRunSync() shouldBe 6
       program.run(1).unsafeRunSync() shouldBe 6
+      program.run.unsafeRunSync() shouldBe 6
     }
 
     it("Should combine Any with a context") {
@@ -195,7 +196,7 @@ class CaioTests extends AsyncFunSpec with Matchers {
           .provideContext((1, 2, 3))
       }
 
-      program.run(()).unsafeRunSync() shouldBe 6
+      program.run.unsafeRunSync() shouldBe 6
     }
   }
 


### PR DESCRIPTION
```scala
type CaioC[C, A] = Caio[C, MyErrorType, MyEventLog, A]
type Caio[A] = CaioC[Any, A]
```

Now that Caio is contravariant in C we gain the ability to easily go from Caio[A] to Caio[C, A] by just adding a type annotation. In the contrarian order we now can use `.provideContext`. A real world example would be:

```scala
object WithContext {
  object Applicator {
    implicit def instanceAny[C]: Applicator[Caio, CaioC[C, ?], C] =
      new Applicator[Caio, CaioC[C, ?], C] {
        def apply[Alg[_]](context: C, service: Alg ~> CaioC[C, ?]): Alg ~> Caio =
          service.andThen(new (CaioC[C, ?] ~> Caio) {
            def apply[A](fa: CaioC[C, A]): Caio[A] = fa.provideContext(context)
          })

        def use[Alg[_]](
          resource: Caio[Resource[Caio, C]],
          service: Alg ~> CaioC[C, ?]
        ): Alg ~> Caio =
          new (Alg ~> Caio) {
            def apply[A](fa: Alg[A]): Caio[A] =
              resource.flatMap(_.use(context => service(fa).provideContext(context)))
          }

        def apply[A](context: C, value: CaioC[C, A]): Caio[A] =
          value.provideContext(context)

        def lift[A](value: Caio[A]): CaioC[C, A] =
          value

        def lift[D[_]](value: D ~> Caio): D ~> CaioC[C, ?] =
          value.andThen(new (Caio ~> CaioC[C, ?]) {
             def apply[A](fa: Caio[A]): CaioC[C, A] = fa
          })
      }
  }
}
```

Yesterday I had an obstacle because C is invariant currently and couldn't find a satisfying workaround. Hope this helps.
