### PR TITLE
Upgrade Scala version to 2.13.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ publishArtifact in(Test, packageDoc) := true
 // enable publishing the test sources jar
 publishArtifact in(Test, packageSrc) := true
 
-val currentScalaVersion = "2.13.1"
+val currentScalaVersion = "2.13.5"
 ThisBuild / scalaVersion := currentScalaVersion
 crossScalaVersions := Seq("2.12.13", currentScalaVersion)
 
@@ -42,7 +42,6 @@ scalacOptions ++= Seq(
   "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
   "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
   "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-  "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
   "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
   "-Xlint:option-implicit", // Option.apply used implicit view.
   "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
@@ -60,7 +59,10 @@ scalacOptions ++= Seq(
 ) ++ {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, v)) if v <= 12 =>
-      Seq("-Ypartial-unification")
+      Seq(
+        "-Ypartial-unification",
+        "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+      )
     case _ =>
       Seq("-Ymacro-annotations")
   }

--- a/src/main/scala-2.12/caio/mtl/ContextProjector.scala
+++ b/src/main/scala-2.12/caio/mtl/ContextProjector.scala
@@ -2,7 +2,7 @@ package caio.mtl
 
 import cats.mtl.{ApplicativeAsk, MonadState}
 import io.typechecked.alphabetsoup.Mixer
-import shapeless.{=:!=, LowPriority}
+import shapeless.=:!=
 
 trait ContextProjector {
 
@@ -15,35 +15,33 @@ trait ContextProjector {
     AP.A
 
   implicit def extenderAskProjection[M[_], A, B]
-    (implicit E:Extender[M, A], M:Mixer[A, B]):AskProjection[M, B] =
-    AskProjection{
+    (implicit E: Extender[M, A], M: Mixer[A, B]): AskProjection[M, B] =
+    AskProjection {
       new MixedApplicativeAsk[M, A, B](E.applicativeAsk)
     }
 
   implicit def askAskProjection[M[_], A, B]
-    (implicit AA:ApplicativeAsk[M, A], M:Mixer[A, B], EV: A =:!= B):AskProjection[M, B] =
-    AskProjection{
+    (implicit AA: ApplicativeAsk[M, A], M: Mixer[A, B], EV: A =:!= B): AskProjection[M, B] =
+    AskProjection {
       new MixedApplicativeAsk[M, A, B](AA)
     }
 
   implicit def stateStateProjection[M[_], A, B]
-    (implicit MS:MonadState[M, A], M:Mixer[A, B]):StateProjection[M, B] =
-    StateProjection{
+    (implicit MS: MonadState[M, A], M: Mixer[A, B]): StateProjection[M, B] =
+    StateProjection {
       new MixedMonadState[M, A, B](MS)
     }
 
   implicit def extenderStateProjection[M[_], A, B]
-    (implicit E:Extender[M, A], M:Mixer[A, B]):StateProjection[M, B] =
-    StateProjection{
+    (implicit E: Extender[M, A], M: Mixer[A, B]): StateProjection[M, B] =
+    StateProjection {
       new MixedMonadState[M, A, B](E.monadState)
     }
 
 }
 
-
-
-case class AskProjection[M[_], A](A:ApplicativeAsk[M, A]) extends AnyVal
-case class StateProjection[M[_], A](MS:MonadState[M, A]) extends AnyVal
+case class AskProjection[M[_], A](A: ApplicativeAsk[M, A]) extends AnyVal
+case class StateProjection[M[_], A](MS: MonadState[M, A]) extends AnyVal
 
 object ContextProjector extends ContextProjector
 

--- a/src/main/scala-2.13/caio/mtl/ContextProjector.scala
+++ b/src/main/scala-2.13/caio/mtl/ContextProjector.scala
@@ -15,41 +15,33 @@ trait ContextProjector {
     AP.A
 
   implicit def extenderAskProjection[M[_], A, B]
-    (implicit E:Extender[M, A], M:Mixer[A, B]):AskProjection[M, B] =
-    AskProjection{
+    (implicit E: Extender[M, A], M: Mixer[A, B]): AskProjection[M, B] =
+    AskProjection {
       new MixedApplicativeAsk[M, A, B](E.applicativeAsk)
     }
 
   implicit def askAskProjection[M[_], A, B]
-    (implicit AA:ApplicativeAsk[M, A], M:Mixer[A, B], EV: A =:!= B):AskProjection[M, B] =
-    AskProjection{
+    (implicit AA: ApplicativeAsk[M, A], M: Mixer[A, B], ev0: A =:!= B, ev1: LowPriority): AskProjection[M, B] =
+    AskProjection {
       new MixedApplicativeAsk[M, A, B](AA)
     }
 
   implicit def stateStateProjection[M[_], A, B]
-    (implicit MS:MonadState[M, A], M:Mixer[A, B]):StateProjection[M, B] =
-    StateProjection{
+    (implicit MS: MonadState[M, A], M: Mixer[A, B], ev: LowPriority): StateProjection[M, B] =
+    StateProjection {
       new MixedMonadState[M, A, B](MS)
     }
 
-  implicit def stateAskProjection[M[_], A, B]
-    (implicit MS:MonadState[M, A], M:Mixer[A, B], ev: LowPriority):AskProjection[M, B] =
-    AskProjection[M, B]{
-      new MixedState2ApplicativeAsk(MS)
-    }
-
   implicit def extenderStateProjection[M[_], A, B]
-    (implicit E:Extender[M, A], M:Mixer[A, B]):StateProjection[M, B] =
-    StateProjection{
+    (implicit E: Extender[M, A], M: Mixer[A, B]): StateProjection[M, B] =
+    StateProjection {
       new MixedMonadState[M, A, B](E.monadState)
     }
 
 }
 
-
-
-case class AskProjection[M[_], A](A:ApplicativeAsk[M, A]) extends AnyVal
-case class StateProjection[M[_], A](MS:MonadState[M, A]) extends AnyVal
+case class AskProjection[M[_], A](A: ApplicativeAsk[M, A]) extends AnyVal
+case class StateProjection[M[_], A](MS: MonadState[M, A]) extends AnyVal
 
 object ContextProjector extends ContextProjector
 

--- a/src/main/scala/caio/mtl/ContextCombinator.scala
+++ b/src/main/scala/caio/mtl/ContextCombinator.scala
@@ -48,6 +48,6 @@ trait ContextCombinator {
 
 }
 
-case class AskCombinator[M[_], A](A:ApplicativeAsk[M, A]) extends AnyVal
+case class AskCombinator[M[_], A](A: ApplicativeAsk[M, A]) extends AnyVal
 
 object ContextCombinator extends ContextCombinator

--- a/src/test/scala/caio/mtl/ContextProjectorTests.scala
+++ b/src/test/scala/caio/mtl/ContextProjectorTests.scala
@@ -6,15 +6,15 @@ import org.scalatest.{AsyncFunSpec, Matchers}
 class ContextProjectorTests extends AsyncFunSpec with Matchers{
 
   class AskInt[M[_]: ApplicativeAsk[*[_], Int]] {
-    def run:M[Int] = ApplicativeAsk[M,Int].ask
+    def run: M[Int] = ApplicativeAsk[M,Int].ask
   }
 
   class AskString[M[_]: ApplicativeAsk[*[_], String]] {
-    def run:M[String] = ApplicativeAsk[M, String].ask
+    def run: M[String] = ApplicativeAsk[M, String].ask
   }
 
   class AskIntString[M[_]: ApplicativeAsk[*[_], (Int, String)]] {
-    import caio.mtl.ContextProjector.{projectApplicativeAsk, askAskProjection}
+    import caio.mtl.ContextProjector._
 
     val ai = new AskInt[M]
 
@@ -22,27 +22,26 @@ class ContextProjectorTests extends AsyncFunSpec with Matchers{
   }
 
   class AskIntIgnore[M[_]: ApplicativeAsk[*[_], Int]] {
-    import caio.mtl.ContextProjector.{projectApplicativeAsk, askAskProjection}
+    import caio.mtl.ContextProjector._
 
     val ai = new AskInt[M]
   }
 
   class MonadInt[M[_]: MonadState[*[_], Int]] {
-    def run:M[Int] = MonadState[M,Int].get
+    def run: M[Int] = MonadState[M,Int].get
   }
 
   class MonadString[M[_]: MonadState[*[_], String]] {
-    def run:M[String] = MonadState[M, String].get
+    def run: M[String] = MonadState[M, String].get
   }
 
   class MonadIntString[M[_]: MonadState[*[_], (Int, String)]] {
-    import caio.mtl.ContextProjector.{projectMonadState, stateStateProjection}
+    import caio.mtl.ContextProjector._
 
     val ai = new MonadInt[M]
 
     val as = new MonadString[M]
   }
-
 
   class MonadIntAskString[M[_]: MonadState[*[_], (Int, String)]] {
     import caio.mtl.ContextCombinator.{combinatorAsk, stateCombinator}

--- a/src/test/scala/caio/mtl/ContextTests.scala
+++ b/src/test/scala/caio/mtl/ContextTests.scala
@@ -4,39 +4,37 @@ import cats.mtl.{ApplicativeAsk, MonadState}
 
 class ContextTests {
 
-  class AskInt[M[_]:ApplicativeAsk[*[_], Int]] {
-    def run:M[Int] = ApplicativeAsk[M,Int].ask
+  class AskInt[M[_]: ApplicativeAsk[*[_], Int]] {
+    def run: M[Int] = ApplicativeAsk[M,Int].ask
   }
 
-  class AskString[M[_]:ApplicativeAsk[*[_], String]] {
-    def run:M[String] = ApplicativeAsk[M, String].ask
+  class AskString[M[_]: ApplicativeAsk[*[_], String]] {
+    def run: M[String] = ApplicativeAsk[M, String].ask
   }
 
-  class AskIntString[M[_]:ApplicativeAsk[*[_], (Int, String)]] {
-    def run:M[(Int, String)] = ApplicativeAsk[M,(Int, String)].ask
+  class AskIntString[M[_]: ApplicativeAsk[*[_], (Int, String)]] {
+    def run: M[(Int, String)] = ApplicativeAsk[M,(Int, String)].ask
   }
 
-  class AskIntBoolean[M[_]:ApplicativeAsk[*[_], (Int, Boolean)]] {
-    def run:M[(Int, Boolean)] = ApplicativeAsk[M,(Int, Boolean)].ask
+  class AskIntBoolean[M[_]: ApplicativeAsk[*[_], (Int, Boolean)]] {
+    def run: M[(Int, Boolean)] = ApplicativeAsk[M,(Int, Boolean)].ask
   }
 
-  class AskIntBooleanString[M[_]:ApplicativeAsk[*[_], (Int, Boolean, String)]] {
-    def run:M[(Int, Boolean, String)] = ApplicativeAsk[M,(Int, Boolean, String)].ask
+  class AskIntBooleanString[M[_]: ApplicativeAsk[*[_], (Int, Boolean, String)]] {
+    def run: M[(Int, Boolean, String)] = ApplicativeAsk[M,(Int, Boolean, String)].ask
   }
 
-
-  class StateString[M[_]:MonadState[*[_], String]] {
-    def run:M[String] = MonadState[M, String].get
+  class StateString[M[_]: MonadState[*[_], String]] {
+    def run: M[String] = MonadState[M, String].get
   }
 
-  class StateIntString[M[_]:MonadState[*[_], (Int, String)]] {
-    def run:M[(Int, String)] = MonadState[M,(Int, String)].get
+  class StateIntString[M[_]: MonadState[*[_], (Int, String)]] {
+    def run: M[(Int, String)] = MonadState[M,(Int, String)].get
   }
 
-  class StateAskIntBooleanString[M[_]:ApplicativeAsk[*[_], (Int, String)]:MonadState[*[_], Boolean]] {
-    def run:M[(Int, Boolean, String)] = ???
+  class StateAskIntBooleanString[M[_]: ApplicativeAsk[*[_], (Int, String)]: MonadState[*[_], Boolean]] {
+    def run: M[(Int, Boolean, String)] = ???
   }
-
 
   class AddAskContext[M[_]](implicit C:Provider[M]) {
 
@@ -106,8 +104,9 @@ class ContextTests {
 
   }
 
-  class AskContextNested2[M[_]:Extender[*[_], (Int, String)]] {
+  class AskContextNested2[M[_]: Extender[*[_], (Int, String)]] {
     import ContextProjector._
+
     val string2 = new AskString[M]
 
     val e = implicitly[Extender[M, (Int, String)]].apply[Boolean]
@@ -123,7 +122,6 @@ class ContextTests {
     val string1 = new AskString[e.FE]
   }
 
-
   class MixContext2[M[_]:Provider] {
 
     val e:Provides[M, String] =
@@ -136,13 +134,13 @@ class ContextTests {
     val nested = new MixContextNested[e.FE]()
   }
 
-  class MixContextNested[M[_]:Extender[*[_], String]:MonadState[*[_], String]] {
+  class MixContextNested[M[_]: Extender[*[_], String]: MonadState[*[_], String]] {
 
 
     val string2 = new StateString[M]
 
     val string4 = {
-      import ContextCombinator._
+      import ContextCombinator.{combinatorAsk, stateCombinator}
       new AskString[M]
     }
 
@@ -158,9 +156,9 @@ class ContextTests {
     val string3 = new AskString[e.FE]
   }
 
-  class AddContextMixed2[M[_]:Extender[*[_], (Int, String)]] {
+  class AddContextMixed2[M[_]: Extender[*[_], (Int, String)]] {
 
-    val (string2, intString, intString2) = {
+    val (string2, intString , intString2) = {
       import ContextProjector._
       (new AskString[M], new AskIntString[M], new StateIntString[M])
     }
@@ -179,8 +177,7 @@ class ContextTests {
     val string1 = new AskString[e.FE]
   }
 
-
-  class DoubleExtended[M[_]:Extender[*[_], Int]] {
+  class DoubleExtended[M[_]: Extender[*[_], Int]] {
 
     //Cannot have 2 Extends implicits in scope at the same time
     val ES: Extends[M, Int, String] = implicitly[Extender[M, Int]].apply[String]
@@ -198,11 +195,9 @@ class ContextTests {
     def run():(M[(Int, String)], M[(Int, Boolean)]) =
       ES.apply("String")(service1.run) ->
       EB.apply(false)(service2.run)
-
-
   }
 
-  class DoubleExtendedHierarchical[M[_]:Extender[*[_], Int]] {
+  class DoubleExtendedHierarchical[M[_]: Extender[*[_], Int]] {
 
     //Cannot have 2 Extends implicits in scope at the same time
     val ES = implicitly[Extender[M, Int]].apply[Boolean]
@@ -220,9 +215,5 @@ class ContextTests {
     def run() =
       ES.apply(false)(service1.run) ->
         ES.apply(false)(EB.apply("bob")(service2.run))
-
-
   }
-
-
 }

--- a/src/test/scala/caio/std/CaioExtendedMtlTests.scala
+++ b/src/test/scala/caio/std/CaioExtendedMtlTests.scala
@@ -16,18 +16,18 @@ class CaioExtendedMtlTests extends AsyncFunSpec with Matchers{
       :FunctorListen[*[_], Event]
       :ApplicativeFail[*[_], Failure]:Monad]{
 
-    def eval():M[String] =
-    for {
-      a <- implicitly[ApplicativeAsk[M, Atomic1]].ask
-      _ <- implicitly[FunctorListen[M, Event]].writer((), Event.event1)
-    } yield "Nested1:" + a.value
+    def eval(): M[String] =
+      for {
+        a <- implicitly[ApplicativeAsk[M, Atomic1]].ask
+        _ <- implicitly[FunctorListen[M, Event]].writer((), Event.event1)
+      } yield "Nested1:" + a.value
 
-    def evalFail():M[String] =
+    def evalFail(): M[String] =
       eval().flatMap{a =>
         implicitly[ApplicativeFail[M, Failure]].fail(Failure.failure1)
       }
 
-    def evalHandle():M[String] =
+    def evalHandle(): M[String] =
       implicitly[ApplicativeFail[M, Failure]].handleFailuresWith(evalFail()){nl =>
         implicitly[Applicative[M]].pure("Nested1:failure:" + nl.head.value)
       }
@@ -38,23 +38,23 @@ class CaioExtendedMtlTests extends AsyncFunSpec with Matchers{
       :ApplicativeAsk[*[_], Atomic2]
       :LiftIO:MonadError[*[_], Throwable]]{
 
-    def eval():M[String] =
+    def eval(): M[String] =
       for {
         a <- implicitly[ApplicativeAsk[M, Atomic2]].ask
         time <- implicitly[LiftIO[M]].liftIO(IO.delay(System.currentTimeMillis()))
       } yield "Nested2:" + a.value + ":" + time
 
-    def evalError():M[String] =
+    def evalError(): M[String] =
       eval().flatMap{_ =>
         implicitly[MonadError[M, Throwable]].raiseError(Exception.exception1)
       }
 
-    def evalHandle():M[String] =
+    def evalHandle(): M[String] =
       implicitly[MonadError[M, Throwable]]
         .handleError(evalError())(e => "Nested2:exception:" + e.toString)
   }
 
-  class Nested3[M[_]:MonadState[*[_], Atomic3]:Sync]{
+  class Nested3[M[_]: MonadState[*[_], Atomic3]: Sync]{
 
     def eval():M[String] =
       for {
@@ -69,7 +69,6 @@ class CaioExtendedMtlTests extends AsyncFunSpec with Matchers{
       :FunctorListen[*[_], Event]
       :ApplicativeFail[*[_], Failure]
       :Sync] {
-
 
     val nested1 = {
       import ContextProjector._
@@ -88,32 +87,32 @@ class CaioExtendedMtlTests extends AsyncFunSpec with Matchers{
       new Nested3[E3.FE]
     }
 
-    def eval(atomic2:Atomic2, atomic3:Atomic3):M[(String, String, String)] =
+    def eval(atomic2: Atomic2, atomic3: Atomic3): M[(String, String, String)] =
       for {
         n1 <- nested1.eval()
         n2 <- E2.apply(atomic2)(nested2.eval())
         n3 <- E3.apply(atomic3)(nested3.eval())
       } yield (n1, n2, n3)
 
-    def evalFail(atomic2:Atomic2):M[(String, String)] =
+    def evalFail(atomic2: Atomic2): M[(String, String)] =
       for {
         n2 <- E2.apply(atomic2)(nested2.eval())
         n1 <- nested1.evalFail()
       } yield n1 -> n2
 
-    def evalError(atomic2:Atomic2, atomic3:Atomic3):M[(String, String)] =
+    def evalError(atomic2: Atomic2, atomic3: Atomic3): M[(String, String)] =
       for {
         n3 <- E3.apply(atomic3)(nested3.eval())
         n2 <- E2.apply(atomic2)(nested2.evalError())
       } yield n2 -> n3
 
-    def evalFailHandle(atomic2:Atomic2):M[(String, String)] =
+    def evalFailHandle(atomic2: Atomic2): M[(String, String)] =
       for {
         n2 <- E2.apply(atomic2)(nested2.eval())
         n1 <- nested1.evalHandle()
       } yield n1 -> n2
 
-    def evalErrorHandle(atomic2:Atomic2, atomic3:Atomic3):M[(String, String)] =
+    def evalErrorHandle(atomic2: Atomic2, atomic3: Atomic3): M[(String, String)] =
       for {
         n3 <- E3.apply(atomic3)(nested3.eval())
         n2 <- E2.apply(atomic2)(nested2.evalHandle())
@@ -141,6 +140,5 @@ class CaioExtendedMtlTests extends AsyncFunSpec with Matchers{
 
     def evalErrorHandle(atomic1:Atomic1, atomic2:Atomic2, atomic3:Atomic3):M[(String, String)] =
       E.apply(atomic1)(extendsNested.evalErrorHandle(atomic2, atomic3))
-
   }
 }


### PR DESCRIPTION
### Implicit resolution issue

**Functions:**

```scala
def projectApplicativeAsk: AskProjection => ApplicativeAsk
def extenderStateProjection: Extender => StateProjection
def projectMonadState: StateProjection => MonadState
def askAskProjection: ApplicativeAsk => AskProjection
def stateAskProjection: MonadState => AskProjection
```

**Resolution:**

Extender 	====> (extenderStateProjection)
StateProjection ====> (projectMonadState)
MonadState 	====> (stateAskProjection)
AskProjection 	====> (projectApplicativeAsk)
ApplicativeAsk	====> (askAskProjection)
AskProjection

**Graphic representation:**

[![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVERcbiAgICBBKEV4dGVuZGVyKSAtLT58ZXh0ZW5kZXJTdGF0ZVByb2plY3Rpb258IEIoU3RhdGVQcm9qZWN0aW9uKVxuICAgIEIgLS0-fHByb2plY3RNb25hZFN0YXRlfCBDKE1vbmFkU3RhdGUpXG4gICAgQyAtLT58c3RhdGVBc2tQcm9qZWN0aW9ufCBEKEFza1Byb2plY3Rpb24pXG4gICAgRCAtLT58cHJvamVjdEFwcGxpY2F0aXZlQXNrfCBFW0FwcGxpY2F0aXZlQXNrXVxuICAgIEUgLS0-fGFza0Fza1Byb2plY3Rpb258IEQiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVERcbiAgICBBKEV4dGVuZGVyKSAtLT58ZXh0ZW5kZXJTdGF0ZVByb2plY3Rpb258IEIoU3RhdGVQcm9qZWN0aW9uKVxuICAgIEIgLS0-fHByb2plY3RNb25hZFN0YXRlfCBDKE1vbmFkU3RhdGUpXG4gICAgQyAtLT58c3RhdGVBc2tQcm9qZWN0aW9ufCBEKEFza1Byb2plY3Rpb24pXG4gICAgRCAtLT58cHJvamVjdEFwcGxpY2F0aXZlQXNrfCBFW0FwcGxpY2F0aXZlQXNrXVxuICAgIEUgLS0-fGFza0Fza1Byb2plY3Rpb258IEQiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)

**Portion of stacktrace:**

(Sometimes it prints out Stackoverflow instead of null)
```java
[error] null
[error] scala.reflect.internal.Symbols$Symbol.isOverridableMember(Symbols.scala:698)
[error] scala.reflect.internal.Types.rebind(Types.scala:3993)
[error] scala.reflect.internal.Types.typeRef(Types.scala:4075)
[error] scala.reflect.internal.Types.typeRef$(Types.scala:4069)
[error] scala.reflect.internal.Symbols$TypeSymbol.newTypeRef(Symbols.scala:3196)
[error] scala.reflect.internal.Symbols$TypeSymbol.typeConstructor(Symbols.scala:3218)
[error] scala.reflect.internal.Symbols$TypeSymbol.tpeHK(Symbols.scala:3221)
[error] scala.reflect.internal.Types.copyTypeRef(Types.scala:4098)
[error] scala.reflect.internal.Types.copyTypeRef$(Types.scala:4092)
[error] scala.reflect.internal.SymbolTable.copyTypeRef(SymbolTable.scala:28)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.toType(TypeMaps.scala:767)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.toType(TypeMaps.scala:763)
[error] scala.reflect.internal.tpe.TypeMaps$SubstMap.subst(TypeMaps.scala:705)
[error] scala.reflect.internal.tpe.TypeMaps$SubstMap.substFor$1(TypeMaps.scala:730)
[error] scala.reflect.internal.tpe.TypeMaps$SubstMap.apply(TypeMaps.scala:745)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.apply(TypeMaps.scala:792)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.apply(TypeMaps.scala:763)
[error] scala.reflect.internal.Types$TypeRef.mapOver(Types.scala:2380)
[error] scala.reflect.internal.tpe.TypeMaps$SubstMap.apply(TypeMaps.scala:729)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.apply(TypeMaps.scala:792)
[error] scala.reflect.internal.tpe.TypeMaps$SubstSymMap.apply(TypeMaps.scala:763)
[error] scala.reflect.internal.tpe.TypeComparers.isPolySubType(TypeComparers.scala:365)
[error] scala.reflect.internal.tpe.TypeComparers.isSub2$1(TypeComparers.scala:411)
[error] scala.reflect.internal.tpe.TypeComparers.isSub$1(TypeComparers.scala:408)
[error] scala.reflect.internal.tpe.TypeComparers.isHKSubType(TypeComparers.scala:434)
[error] scala.reflect.internal.tpe.TypeComparers.isHKSubType$(TypeComparers.scala:383)
[error] scala.reflect.internal.SymbolTable.isHKSubType(SymbolTable.scala:28)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType2(TypeComparers.scala:447)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType1(TypeComparers.scala:348)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType(TypeComparers.scala:306)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType$(TypeComparers.scala:268)
[error] scala.reflect.internal.SymbolTable.isSubType(SymbolTable.scala:28)
[error] scala.reflect.internal.Types.isSubArg$1(Types.scala:4774)
[error] scala.reflect.internal.Types.$anonfun$isSubArgs$1(Types.scala:4778)
[error] scala.reflect.internal.Types.isSubArgs(Types.scala:4778)
[error] scala.reflect.internal.Types.isSubArgs$(Types.scala:4772)
[error] scala.reflect.internal.SymbolTable.isSubArgs(SymbolTable.scala:28)
[error] scala.reflect.internal.tpe.TypeComparers.firstTry$1(TypeComparers.scala:471)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType2(TypeComparers.scala:616)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType1(TypeComparers.scala:348)
[error] scala.reflect.internal.tpe.TypeComparers.isSubType(TypeComparers.scala:306)
```

**Solution:**

Add LowPriority to askAskProjection & stateStateProjection and remove stateAskProjection.