### PR TITLE
Use Atomic Reference for event logs

### DIFF
--- a/src/main/scala/caio/std/CaioBijectionK.scala
+++ b/src/main/scala/caio/std/CaioBijectionK.scala
@@ -20,20 +20,20 @@ import cats.arrow.FunctionK
 class CaioBijectionK[C1, C2, V, L: Monoid](f: C2 => C1, invF: C1 => C2)
   extends (Caio[C1, V, L, *] <~> Caio[C2, V, L, *]) {
   def apply[A](fa: Caio[C1, V, L, A]): Caio[C2, V, L, A] =
-    KleisliCaio[C2, V, L, A] { c2 =>
-      Caio.foldIO[C1, V, L, A](fa, f(c2)).map(_.contextMap(invF))
+    KleisliCaio[C2, V, L, A] { (c2, ref) =>
+      Caio.foldIO[C1, V, L, A](fa, f(c2), ref).map(_.contextMap(invF))
     }
 
   def unapply[A](fa: Caio[C2, V, L, A]): Caio[C1, V, L, A] =
-    KleisliCaio[C1, V, L, A] { c1 =>
-      Caio.foldIO[C2, V, L, A](fa, invF(c1)).map(_.contextMap(f))
+    KleisliCaio[C1, V, L, A] { (c1, ref) =>
+      Caio.foldIO[C2, V, L, A](fa, invF(c1), ref).map(_.contextMap(f))
     }
 
   def invert:Caio[C2, V, L, *] ~> Caio[C1, V, L, *] =
     new FunctionK[Caio[C2, V, L, *], Caio[C1, V, L, *]] {
       def apply[A](fa: Caio[C2, V, L, A]): Caio[C1, V, L, A] =
-        KleisliCaio[C1, V, L, A] { c1 =>
-          Caio.foldIO[C2, V, L, A](fa, invF(c1)).map(_.contextMap(f))
+        KleisliCaio[C1, V, L, A] { (c1, ref) =>
+          Caio.foldIO[C2, V, L, A](fa, invF(c1), ref).map(_.contextMap(f))
         }
     }
 }

--- a/src/main/scala/caio/std/CaioBracket.scala
+++ b/src/main/scala/caio/std/CaioBracket.scala
@@ -2,64 +2,9 @@ package caio.std
 
 import caio._
 import cats.Monoid
-import cats.data.NonEmptyList
-import cats.effect.ExitCase.Error
-import cats.effect.concurrent.Ref
-import cats.effect.{Bracket, ExitCase, IO }
+import cats.effect.{Bracket, ExitCase}
 
 class CaioBracket[C, V, L](implicit M: Monoid[L]) extends CaioMonadError[C, V, L] with Bracket[Caio[C, V, L, *], Throwable] {
-
-  private case class CaptureError(c: C, l: L, cause: Throwable) extends Throwable
-
-  def bracketCase[A, B](acquire: Caio[C, V, L, A])(use: A => Caio[C, V, L, B])(release: (A, ExitCase[Throwable]) => Caio[C, V, L, Unit]): Caio[C, V, L, B] = {
-    KleisliCaio[C, V, L, B] { c =>
-      Ref.of[IO, L](M.empty).flatMap { ref =>
-        Bracket[IO, Throwable].bracketCase[FoldCaioPure[C, V, L, A], FoldCaioPure[C, V, L, B]](Caio.foldIO(acquire, c)) {
-          case FoldCaioSuccess(acquireC, acquireL, a) =>
-            Caio.foldIO(use(a), acquireC).flatMap {
-              case FoldCaioSuccess(useC, useL, b) =>
-                IO.pure(FoldCaioSuccess[C, V, L, B](useC, M.combine(acquireL, useL), b))
-              case FoldCaioError(useC, useL, ex) =>
-                IO.raiseError(CaptureError(useC, M.combine(acquireL, useL), ex))
-              case FoldCaioFailure(useC, useL, h, t) =>
-                IO.raiseError(CaptureError(useC, M.combine(acquireL, useL), CaioUnhandledFailuresException(NonEmptyList(h, t))))
-            }
-          case failOrError =>
-            IO.pure(failOrError.asInstanceOf[FoldCaioPure[C, V, L, B]])
-        } {
-          case (FoldCaioSuccess(acquireC, _, a), exitCase) =>
-            val (newExitCase, forReleaseC) = exitCase match {
-              case Error(CaptureError(useC, _, ex)) =>
-                Error(ex) -> useC
-              case ec =>
-                ec -> acquireC
-            }
-            Caio.foldIO(release(a, newExitCase), forReleaseC)
-              .flatMap(p => ref.set(p.l).map(_ => p))
-              .flatMap {
-                case FoldCaioError(_, _, ex) =>
-                  IO.raiseError(ex)
-                case FoldCaioFailure(_, _, h, t) =>
-                  IO.raiseError(CaioUnhandledFailuresException(NonEmptyList(h, t)))
-                case _ =>
-                  IO.unit
-              }
-          case _ =>
-            IO.unit
-        }.redeemWith(
-          {
-            case CaptureError(useC, l, CaioUnhandledFailuresException(NonEmptyList(head: V, tail: List[V]))) =>
-              ref.get.map { l2 => FoldCaioFailure(useC, M.combine(l, l2), head, tail) }
-            case CaptureError(useC, l, ex) =>
-              ref.get.map { l2 => FoldCaioError(useC, M.combine(l, l2), ex) }
-            case CaioUnhandledFailuresException(NonEmptyList(head: V, tail: List[V])) =>
-              ref.get.map { l => FoldCaioFailure(c, l, head, tail) }
-            case ex =>
-              ref.get.map { l => FoldCaioError(c, l, ex) }
-          },
-          b => ref.get.map { l2 => b.mapL(l => M.combine(l, l2)) }
-        )
-      }
-    }
-  }
+  def bracketCase[A, B](acquire: Caio[C, V, L, A])(use: A => Caio[C, V, L, B])(release: (A, ExitCase[Throwable]) => Caio[C, V, L, Unit]): Caio[C, V, L, B] =
+    acquire.bracketCase(use)(release)
 }

--- a/src/main/scala/caio/std/CaioConcurrent.scala
+++ b/src/main/scala/caio/std/CaioConcurrent.scala
@@ -7,48 +7,8 @@ import cats.effect._
 class CaioConcurrent[C, V, L:Monoid](implicit CS:ContextShift[IO]) extends CaioAsync[C, V, L] with Concurrent[Caio[C, V, L, *]] {
 
   def start[A](fa: Caio[C, V, L, A]): Caio[C, V, L, Fiber[Caio[C, V, L, *], A]] =
-    KleisliCaio[C, V, L, Fiber[Caio[C, V, L, *], A]] { c =>
-      val fiberIO: IO[Fiber[IO, FoldCaioPure[C, V, L, A]]] =
-        Caio.foldIO(fa, c).start
-      fiberIO.map { fiber =>
-        val cancel: IO[Unit] = fiber.cancel
-
-        val join = fiber.join
-        FoldCaioSuccess(c, Monoid[L].empty, Fiber(
-          KleisliCaio[C, V, L, A](_ => join),
-          IOCaio(cancel)
-        ))
-      }
-    }
+    fa.start
 
   def racePair[A, B](fa: Caio[C, V, L, A], fb: Caio[C, V, L, B]): Caio[C, V, L, Either[(A, Fiber[Caio[C, V, L, *], B]), (Fiber[Caio[C, V, L, *], A], B)]] =
-    KleisliCaio[C, V, L, Either[(A, Fiber[Caio[C, V, L, *], B]), (Fiber[Caio[C, V, L, *], A], B)]] { c =>
-      val sa = Caio.foldIO(fa, c)
-      val sb = Caio.foldIO(fb, c)
-      IO.racePair(sa, sb).flatMap {
-        case Left((e: FoldCaioError[C, V, L, _], fiberB)) =>
-          fiberB.cancel.map(_ => e)
-
-        case Left((f: FoldCaioFailure[C, V, L, _], fiberB)) =>
-          fiberB.cancel.map(_ => f)
-
-        case Left((s: FoldCaioSuccess[C, V, L, A], fiberB)) =>
-          IO(s.map(a => Left(a -> fiber2Caio(fiberB))))
-
-        case Right((fiberA, e: FoldCaioError[C, V, L, _])) =>
-          fiberA.cancel.map(_ => e)
-
-        case Right((fiberA, f: FoldCaioFailure[C, V, L, _])) =>
-          fiberA.cancel.map(_ => f)
-
-        case Right((fiberA, s: FoldCaioSuccess[C, V, L, B])) =>
-          IO(s.map(b => Right(fiber2Caio(fiberA) -> b)))
-      }
-    }
-
-  private def fiber2Caio[A](fiber: Fiber[IO, FoldCaioPure[C, V, L, A]]): Fiber[Caio[C, V, L, *], A] = {
-    val cancel: CancelToken[IO] = fiber.cancel
-    val join = KleisliCaio[C, V, L, A](_ => fiber.join)
-    Fiber(join, IOCaio(cancel))
-  }
+    fa.racePair(fb)
 }

--- a/src/main/scala/caio/std/CaioContextShift.scala
+++ b/src/main/scala/caio/std/CaioContextShift.scala
@@ -9,8 +9,8 @@ import scala.concurrent.ExecutionContext
 class CaioContextShift[C, V, L: Monoid](implicit CS: ContextShift[IO]) extends ContextShift[Caio[C, V, L, *]] {
 
   def evalOn[A](ec: ExecutionContext)(fa: Caio[C, V, L, A]): Caio[C, V, L, A] =
-    KleisliCaio[C, V, L, A] { c =>
-      CS.evalOn(ec)(Caio.foldIO(fa, c))
+    KleisliCaio[C, V, L, A] { (c, ref) =>
+      CS.evalOn(ec)(Caio.foldIO(fa, c, ref))
     }
 
   def shift: Caio[C, V, L, Unit] =

--- a/src/main/scala/caio/std/CaioFunctionK.scala
+++ b/src/main/scala/caio/std/CaioFunctionK.scala
@@ -20,8 +20,8 @@ import io.typechecked.alphabetsoup.Mixer
 class CaioFunctionK[C1, C2, V, L: Monoid](f: C2 => C1, invF: (C1, C2) => C2)
   extends FunctionK[Caio[C1, V, L, *],Caio[C2, V, L, *]] {
   def apply[A](fa: Caio[C1, V, L, A]): Caio[C2, V, L, A] =
-    KleisliCaio[C2, V, L, A] { c2 =>
-      Caio.foldIO[C1, V, L, A](fa, f(c2)).map(_.contextMap(c1 => invF(c1, c2)))
+    KleisliCaio[C2, V, L, A] { (c2, ref) =>
+      Caio.foldIO[C1, V, L, A](fa, f(c2), ref).map(_.contextMap(c1 => invF(c1, c2)))
     }
 }
 

--- a/src/main/scala/caio/std/CaioProvider.scala
+++ b/src/main/scala/caio/std/CaioProvider.scala
@@ -51,8 +51,8 @@ case class CaioExtends[C, V, L:Monoid, E1, E2]()(implicit M: Mixer[C, E1], I:Mix
   def functionK: Caio[C, V, L, *] ~> FE =
     new (Caio[C, V, L, *] ~> FE) {
       def apply[A](fa: Caio[C, V, L, A]): Caio[(E1, E2), V, L, A] =
-        KleisliCaio[(E1, E2), V, L, A] { c2 =>
-          Caio.foldIO[C, V, L, A](fa, I.mix(c2._1 -> ())).map(_.contextMap(c => M.mix(c) -> c2._2))
+        KleisliCaio[(E1, E2), V, L, A] { (c2, ref) =>
+          Caio.foldIO[C, V, L, A](fa, I.mix(c2._1 -> ()), ref).map(_.contextMap(c => M.mix(c) -> c2._2))
         }
     }
 

--- a/src/main/scala/caio/std/CaioSync.scala
+++ b/src/main/scala/caio/std/CaioSync.scala
@@ -6,8 +6,8 @@ import cats.effect.Sync
 
 class CaioSync[C, V, L: Monoid] extends CaioBracket[C, V, L] with Sync[Caio[C, V, L, *]] {
   def suspend[A](thunk: => Caio[C, V, L, A]): Caio[C, V, L, A] =
-    KleisliCaio[C, V, L, A]{ c =>
-      Caio.foldIO(thunk, c)
+    KleisliCaio[C, V, L, A]{ case (c, ref) =>
+      Caio.foldIO(thunk, c, ref)
     }
 
   override def delay[A](thunk: => A): Caio[C, V, L, A] =

--- a/src/test/scala/caio/CaioTests.scala
+++ b/src/test/scala/caio/CaioTests.scala
@@ -79,7 +79,7 @@ class CaioTests extends AsyncFunSpec with Matchers {
          for {
             a <- Applicative[CaioT].pure(n)
             c <- summation(n - 1)
-            l <- KleisliCaio[C, V, L, Long]{ ctx => IO.pure(FoldCaioSuccess(ctx, EventMonoid.empty, a + c))}
+            l <- KleisliCaio[C, V, L, Long]{ case (ctx, _) => IO.pure(FoldCaioSuccess(ctx, EventMonoid.empty, a + c)) }
           } yield l
         } else
           Applicative[CaioT].pure(n)

--- a/src/test/scala/caio/std/CaioConcurrentEffectTests.scala
+++ b/src/test/scala/caio/std/CaioConcurrentEffectTests.scala
@@ -99,6 +99,18 @@ class CaioConcurrentEffectTests extends AsyncFunSpec with Matchers {
       run(program(true, true)).toList should contain oneOf(-1, -2)
     }
 
+    it("Should handle logs when a fiber is never joined") {
+      val program =
+        Listen[CaioT, EventLog].listen {
+          for {
+            _ <- effect.start(Tell[CaioT, EventLog].tell(Vector(event1)))
+            _ <- Tell[CaioT, EventLog].tell(Vector(event2))
+          } yield ()
+        }
+
+      run(program)._2 should contain theSameElementsAs Vector(event1, event2)
+    }
+
     it("Should handle logs when a fiber is joined") {
       val program =
         Listen[CaioT, EventLog].listen {


### PR DESCRIPTION
Usage of Atomic Reference to overcome the known event log limitation of forking a Caio and never join it back.